### PR TITLE
[feature] Ensure that `libreadline` is here

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -243,7 +243,7 @@ ensure_ruby () {
         ensure_rbenv
         local rbenv_version_dir="rbenv/versions/$version"
         if [ ! -d "$SUITCASE_DIR/$rbenv_version_dir" ]; then
-            ensure_libreadline_linux
+            ensure_libreadline
             run_rbenv install "$version"
         fi
         ensure_symlink "$rbenv_version_dir" "$SUITCASE_DIR/ruby"
@@ -291,7 +291,7 @@ EOF
 }
 
 # On Ubuntu, libreadline-dev is required to compile the Ruby readline extension.
-ensure_libreadline_linux () {
+ensure_libreadline () {
     if [ "$(uname -s)" = "Linux" ]; then
         if [ ! -f "/usr/include/readline/readline.h" ]; then
             echo -e "\nError: Please install libreadline-dev (e.g. sudo apt-get install -y libreadline-dev)"

--- a/install.sh
+++ b/install.sh
@@ -241,6 +241,7 @@ ensure_ruby () {
     local targetdir="$SUITCASE_DIR/ruby"
     if [ ! -x "$targetdir"/bin/ruby ]; then
         ensure_rbenv
+        ensure_libreadline_linux
         local rbenv_version_dir="rbenv/versions/$version"
         if [ ! -d "$SUITCASE_DIR/$rbenv_version_dir" ]; then
             run_rbenv install "$version"
@@ -290,10 +291,10 @@ EOF
 }
 
 # On Ubuntu, libreadline-dev is required to compile the Ruby readline extension.
-shim_libreadline_linux () {
+ensure_libreadline_linux () {
     if [ "$(uname -s)" = "Linux" ]; then
         if [ ! -f "/usr/include/readline/readline.h" ]; then
-            echo "Please install libreadline-dev (e.g. sudo apt-get install -y libreadline-dev)"
+            echo -e "\nError: Please install libreadline-dev (e.g. sudo apt-get install -y libreadline-dev)"
             exit 1
         fi
     fi
@@ -306,7 +307,6 @@ shims () {
             exit 1
         }
     fi
-    shim_libreadline_linux
 }
 
 shims

--- a/install.sh
+++ b/install.sh
@@ -289,6 +289,16 @@ EOF
     fi
 }
 
+# On Ubuntu, libreadline-dev is required to compile the Ruby readline extension.
+shim_libreadline_linux () {
+    if [ "$(uname -s)" = "Linux" ]; then
+        if [ ! -f "/usr/include/readline/readline.h" ]; then
+            echo "Please install libreadline-dev (e.g. sudo apt-get install -y libreadline-dev)"
+            exit 1
+        fi
+    fi
+}
+
 shims () {
     if ! which git >/dev/null; then
         git() {
@@ -296,6 +306,7 @@ shims () {
             exit 1
         }
     fi
+    shim_libreadline_linux
 }
 
 shims

--- a/install.sh
+++ b/install.sh
@@ -241,9 +241,9 @@ ensure_ruby () {
     local targetdir="$SUITCASE_DIR/ruby"
     if [ ! -x "$targetdir"/bin/ruby ]; then
         ensure_rbenv
-        ensure_libreadline_linux
         local rbenv_version_dir="rbenv/versions/$version"
         if [ ! -d "$SUITCASE_DIR/$rbenv_version_dir" ]; then
+            ensure_libreadline_linux
             run_rbenv install "$version"
         fi
         ensure_symlink "$rbenv_version_dir" "$SUITCASE_DIR/ruby"


### PR DESCRIPTION
When compiling Ruby on Ubuntu 20.04 the libreadline-dev package is 
required to compile the Ruby readline extension. This shim ensure that 
it is present and fail at the beginning of the script to avoid the user 
waiting the end of the ruby installtion to restart.