### PR TITLE
[unfeature] no more default Ansible version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ where
 
 ## List of projects that use `foosible`
 
-* [barsible](https://gitlab.epfl.ch/vpsi/barcode-catalyse.ops/-/blob/master/barsible)
 * [botsible](https://github.com/SaphireVert/gitlabot/blob/master/ansible/botsible)
 * [busible](https://github.com/epfl-si/businesscard.ops/blob/main/ansible/busible)
 * [cataiamsible](https://github.com/epfl-si/catalyse-iam.ops/blob/main/cataiamsible)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ where
 * [juicyble](https://github.com/epfl-dojo/juice-shop-ansible/blob/master/juicyble)
 * [k3sible](https://github.com/epfl-dojo/k3s-ansible/blob/master/k3sible)
 * [lhdsible](https://gitlab.epfl.ch/lhd/ops/-/blob/master/lhdsible)
-* [nocsible](https://github.com/epfl-si/external-noc/blob/master/ansible/nocsible)
+* [nocsible](https://github.com/epfl-si/external-noc/blob/master/nocsible)
 * [paysible](https://github.com/epfl-si/payonline.ops/blob/master/paysible)
 * [possible](https://gitlab.epfl.ch/si-idevfsd/people-dev/-/blob/master/ops/possible)
 * [presensible](https://github.com/epfl-fsd/presence_bot/blob/main/ansible/presensible)

--- a/install.sh
+++ b/install.sh
@@ -174,20 +174,8 @@ ensure_suitcase_ansible_version_set () {
             */botsible)
                 # https://github.com/SaphireVert/gitlabot/issues/10
                 SUITCASE_ANSIBLE_VERSION=3.4.0 ;;
-            */busible)
-                # https://github.com/epfl-si/businesscard.ops/issues/1
-                SUITCASE_ANSIBLE_VERSION=3.4.0 ;;
-            */elasticsible)
-                # https://github.com/epfl-si/search_inside/issues/6
-                SUITCASE_ANSIBLE_VERSION=3.4.0 ;;
-            */exportsible)
-                # https://github.com/epfl-si/infoscience-exports/issues/131
-                SUITCASE_ANSIBLE_VERSION=3.4.0 ;;
             */ictsible)
                 # https://github.com/ponsfrilus/ict-bot/issues/55
-                SUITCASE_ANSIBLE_VERSION=3.4.0 ;;
-            */nocsible)
-                # https://github.com/epfl-si/external-noc/issues/45
                 SUITCASE_ANSIBLE_VERSION=3.4.0 ;;
             */presensible)
                 # https://github.com/epfl-fsd/presence_bot/issues/30

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,9 @@
 #
 # $SUITCASE_DIR (mandatory)       Where to install the goods to
 #
+# $SUITCASE_ANSIBLE_VERSION       The precise version of Ansible to use.
+# (mandatory)
+#
 # $SUITCASE_PYTHON_VERSIONS       A list of acceptable Python versions
 #                                 to use. (A reasonable default value is
 #                                 provided, which will try and make use of
@@ -19,9 +22,6 @@
 # $SUITCASE_RUBY_VERSIONS         A list of acceptable Ruby versions to use.
 #                                 Ignored if $SUITCASE_NO_EYAML is set.
 #                                 A reasonable default value is provided.
-#
-# $SUITCASE_ANSIBLE_VERSION       The precise version of Ansible to use.
-#                                 (A reasonable default value is provided)
 #
 # $SUITCASE_PIP_EXTRA             Additional modules to install with `pip install`
 #                                 (separated with spaces)
@@ -96,7 +96,6 @@ if [ -z "$SUITCASE_RUBY_VERSIONS" ]; then
     fi
 fi
 
-: ${SUITCASE_ANSIBLE_VERSION:=3.4.0}
 : ${SUITCASE_EYAML_VERSION:=3.2.0}
 : ${SUITCASE_WITH_EYAML:=0}
 : ${SUITCASE_WITH_KEYBASE:=1}
@@ -110,6 +109,7 @@ satisfied=
 unsatisfied=
 
 main () {
+    ensure_suitcase_ansible_version_set
     ensure_git
 
     [ -n "$SUITCASE_DIR" ] || fatal "SUITCASE_DIR is not set; don't know where to install"
@@ -165,6 +165,47 @@ fatal () {
     echo >&2; echo >&2
     warn "$@"
     exit 1
+}
+
+ensure_suitcase_ansible_version_set () {
+    # https://github.com/epfl-si/ansible.suitcase/issues/7
+    if [ -z "$SUITCASE_ANSIBLE_VERSION" ]; then
+        case "/$0" in
+            */botsible)
+                # https://github.com/SaphireVert/gitlabot/issues/10
+                SUITCASE_ANSIBLE_VERSION=3.4.0 ;;
+            */busible)
+                # https://github.com/epfl-si/businesscard.ops/issues/1
+                SUITCASE_ANSIBLE_VERSION=3.4.0 ;;
+            */elasticsible)
+                # https://github.com/epfl-si/search_inside/issues/6
+                SUITCASE_ANSIBLE_VERSION=3.4.0 ;;
+            */exportsible)
+                # https://github.com/epfl-si/infoscience-exports/issues/131
+                SUITCASE_ANSIBLE_VERSION=3.4.0 ;;
+            */ictsible)
+                # https://github.com/ponsfrilus/ict-bot/issues/55
+                SUITCASE_ANSIBLE_VERSION=3.4.0 ;;
+            */nocsible)
+                # https://github.com/epfl-si/external-noc/issues/45
+                SUITCASE_ANSIBLE_VERSION=3.4.0 ;;
+            */presensible)
+                # https://github.com/epfl-fsd/presence_bot/issues/30
+                SUITCASE_ANSIBLE_VERSION=3.4.0 ;;
+            */tulsible)
+                # https://github.com/epfl-si/ops.tuleap/issues/1
+                SUITCASE_ANSIBLE_VERSION=3.4.0 ;;
+            *)
+                fatal <<'PLEASE_SET_SUITCASE_ANSIBLE_VERSION'
+Please set SUITCASE_ANSIBLE_VERSION upon invoking the suitcase, e.g.
+
+curl https://raw.githubusercontent.com/epfl-si/ansible.suitcase/master/install.sh | \
+   SUITCASE_ANSIBLE_VERSION=3.4.0 sh -x
+      
+PLEASE_SET_SUITCASE_ANSIBLE_VERSION
+                ;;
+        esac
+    fi
 }
 
 satisfied () {


### PR DESCRIPTION
... Except when grandfathered, in which case the previous default version (3.4.0) continues to be supported until such time that the corresponding upstream projects fix the corresponding issue (either by setting `SUITCASE_ANSIBLE_VERSION` on their end, or by closing shop completely e.g. `tulsible`).

- Do some cleanup in [README.md](https://github.com/epfl-si/ansible.suitcase/blob/master/README.md) while we're here.